### PR TITLE
simplified encoding access for the cli

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.16.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.16.x]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go

--- a/cmd/gravl/gravl.go
+++ b/cmd/gravl/gravl.go
@@ -29,7 +29,6 @@ import (
 	"github.com/bzimmer/gravl/pkg/commands/activity/wta"
 	"github.com/bzimmer/gravl/pkg/commands/activity/zwift"
 	"github.com/bzimmer/gravl/pkg/commands/analysis"
-	"github.com/bzimmer/gravl/pkg/commands/encoding"
 	"github.com/bzimmer/gravl/pkg/commands/geo/gnis"
 	"github.com/bzimmer/gravl/pkg/commands/geo/gpx"
 	"github.com/bzimmer/gravl/pkg/commands/geo/srtm"
@@ -43,17 +42,6 @@ import (
 )
 
 func main() {
-	initEncoding := gravl.InitEncoding(
-		func(c *cli.Context) encoding.Encoder {
-			return encoding.GPX(c.App.Writer, c.Bool("compact"))
-		},
-		func(c *cli.Context) encoding.Encoder {
-			return encoding.GeoJSON(c.App.Writer, c.Bool("compact"))
-		},
-		func(c *cli.Context) encoding.Encoder {
-			return encoding.Named(c.App.Writer, c.Bool("compact"))
-		},
-	)
 	initAnalysis := func(c *cli.Context) error {
 		analysis.Add(ageride.New(), false)
 		analysis.Add(benford.New(), false)
@@ -97,7 +85,7 @@ func main() {
 		Description: "Activity related analysis, exploration, & planning",
 		Flags:       gravl.Flags("gravl.yaml"),
 		Commands:    commands,
-		Before:      gravl.Befores(gravl.InitLogging(), initEncoding, gravl.InitConfig(), initAnalysis),
+		Before:      gravl.Befores(gravl.InitLogging(), gravl.InitEncoding(), gravl.InitConfig(), initAnalysis),
 		ExitErrHandler: func(c *cli.Context, err error) {
 			if err == nil {
 				return

--- a/pkg/commands/activity/cyclinganalytics/cyclinganalytics.go
+++ b/pkg/commands/activity/cyclinganalytics/cyclinganalytics.go
@@ -36,7 +36,7 @@ func athlete(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	return encoding.Encode(athlete)
+	return encoding.For(c).Encode(athlete)
 }
 
 var athleteCommand = &cli.Command{
@@ -57,8 +57,9 @@ func activities(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	enc := encoding.For(c)
 	for _, ride := range rides {
-		if err := encoding.Encode(ride); err != nil {
+		if err := enc.Encode(ride); err != nil {
 			return err
 		}
 	}
@@ -88,6 +89,7 @@ func ride(c *cli.Context) error {
 	opts := cyclinganalytics.RideOptions{
 		Streams: []string{"latitude", "longitude", "elevation"},
 	}
+	enc := encoding.For(c)
 	args := c.Args()
 	for i := 0; i < args.Len(); i++ {
 		ctx, cancel := context.WithTimeout(c.Context, c.Duration("timeout"))
@@ -100,7 +102,7 @@ func ride(c *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		if err = encoding.Encode(ride); err != nil {
+		if err = enc.Encode(ride); err != nil {
 			return err
 		}
 	}
@@ -122,7 +124,7 @@ var streamsetsCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
-		if err := encoding.Encode(client.Rides.StreamSets()); err != nil {
+		if err := encoding.For(c).Encode(client.Rides.StreamSets()); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/commands/activity/file.go
+++ b/pkg/commands/activity/file.go
@@ -49,7 +49,7 @@ func Write(c *cli.Context, exp *activity.Export) error {
 	if err != nil {
 		return err
 	}
-	return encoding.Encode(exp)
+	return encoding.For(c).Encode(exp)
 }
 
 // CollectFunc returns true if the file should be uploaded, false otherwise

--- a/pkg/commands/activity/file_test.go
+++ b/pkg/commands/activity/file_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/bzimmer/gravl/pkg/commands"
 	actcmd "github.com/bzimmer/gravl/pkg/commands/activity"
+	"github.com/bzimmer/gravl/pkg/commands/encoding"
 	"github.com/bzimmer/gravl/pkg/providers/activity"
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v2"
@@ -30,7 +31,6 @@ func TestOutputOverwrite(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Skip(tt.name)
 			a := assert.New(t)
 			writer := &bytes.Buffer{}
 			app := &cli.App{
@@ -42,6 +42,9 @@ func TestOutputOverwrite(t *testing.T) {
 				Action: func(c *cli.Context) error {
 					exp := &activity.Export{File: &activity.File{Name: tt.name, Reader: strings.NewReader(tt.name)}}
 					return actcmd.Write(c, exp)
+				},
+				Metadata: map[string]interface{}{
+					"enc": encoding.JSON(ioutil.Discard, true),
 				},
 			}
 			var args = []string{""}

--- a/pkg/commands/activity/internal/testsuite.go
+++ b/pkg/commands/activity/internal/testsuite.go
@@ -49,7 +49,8 @@ func (s *ActivityTestSuite) SetupSuite() {
 }
 
 func (s *ActivityTestSuite) BeforeTest(suiteName, testName string) {
-	s.T().Parallel()
+	// @todo(bzimmer) a race condition exists in the testing library if the suite is run in parallel
+	// s.T().Parallel()
 }
 
 func (s *ActivityTestSuite) TestAthlete() {

--- a/pkg/commands/activity/qp/qp.go
+++ b/pkg/commands/activity/qp/qp.go
@@ -19,15 +19,16 @@ import (
 	"github.com/bzimmer/gravl/pkg/commands/activity/rwgps"
 	"github.com/bzimmer/gravl/pkg/commands/activity/strava"
 	"github.com/bzimmer/gravl/pkg/commands/activity/zwift"
-	"github.com/bzimmer/gravl/pkg/commands/encoding"
+	enccmd "github.com/bzimmer/gravl/pkg/commands/encoding"
 	"github.com/bzimmer/gravl/pkg/providers/activity"
 )
 
 type qr struct {
-	p activity.Poller
-	e activity.Exporter
-	u activity.Uploader
-	d time.Duration
+	p   activity.Poller
+	e   activity.Exporter
+	u   activity.Uploader
+	d   time.Duration
+	enc enccmd.Encoder
 }
 
 func newqr(c *cli.Context) (*qr, error) {
@@ -40,7 +41,8 @@ func newqr(c *cli.Context) (*qr, error) {
 		return nil, err
 	}
 	d := c.Duration("timeout")
-	return &qr{e: e, u: u, p: p, d: d}, nil
+	enc := enccmd.For(c)
+	return &qr{e: e, u: u, p: p, d: d, enc: enc}, nil
 }
 
 func exporter(c *cli.Context) (activity.Exporter, error) {
@@ -119,7 +121,7 @@ func (q *qr) upload(ctx context.Context, export *activity.Export) error {
 		if res.Err != nil {
 			return res.Err
 		}
-		if err := encoding.Encode(res.Upload); err != nil {
+		if err := q.enc.Encode(res.Upload); err != nil {
 			return err
 		}
 	}

--- a/pkg/commands/activity/rwgps/rwgps.go
+++ b/pkg/commands/activity/rwgps/rwgps.go
@@ -36,7 +36,7 @@ func athlete(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	err = encoding.Encode(user)
+	err = encoding.For(c).Encode(user)
 	if err != nil {
 		return err
 	}
@@ -73,8 +73,9 @@ func trips(c *cli.Context, kind string) error {
 	if err != nil {
 		return err
 	}
+	enc := encoding.For(c)
 	for _, trip := range trips {
-		err = encoding.Encode(trip)
+		err = enc.Encode(trip)
 		if err != nil {
 			return err
 		}
@@ -117,6 +118,7 @@ func entity(c *cli.Context, f func(context.Context, *rwgps.Client, int64) (inter
 	if err != nil {
 		return err
 	}
+	enc := encoding.For(c)
 	args := c.Args()
 	for i := 0; i < args.Len(); i++ {
 		ctx, cancel := context.WithTimeout(c.Context, c.Duration("timeout"))
@@ -129,7 +131,7 @@ func entity(c *cli.Context, f func(context.Context, *rwgps.Client, int64) (inter
 		if err != nil {
 			return err
 		}
-		if err = encoding.Encode(v); err != nil {
+		if err = enc.Encode(v); err != nil {
 			return err
 		}
 	}

--- a/pkg/commands/activity/strava/api.go
+++ b/pkg/commands/activity/strava/api.go
@@ -41,7 +41,7 @@ func athlete(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	return encoding.Encode(athlete)
+	return encoding.For(c).Encode(athlete)
 }
 
 var athleteCommand = &cli.Command{
@@ -62,7 +62,7 @@ func refresh(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	return encoding.Encode(tokens)
+	return encoding.For(c).Encode(tokens)
 }
 
 var refreshCommand = &cli.Command{
@@ -114,6 +114,8 @@ func activities(c *cli.Context) error {
 		return err
 	}
 
+	enc := encoding.For(c)
+
 	var ok bool
 	var res *strava.ActivityResult
 	acts := client.Activity.Activities(ctx, activity.Pagination{Total: c.Int("count")})
@@ -142,7 +144,7 @@ func activities(c *cli.Context) error {
 				return err
 			}
 			// encode
-			if err = encoding.Encode(res); err != nil {
+			if err = enc.Encode(res); err != nil {
 				return err
 			}
 		}
@@ -189,8 +191,9 @@ func routes(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	enc := encoding.For(c)
 	for _, route := range routes {
-		err = encoding.Encode(route)
+		err = enc.Encode(route)
 		if err != nil {
 			return err
 		}
@@ -231,6 +234,8 @@ func entityWithArgs(c *cli.Context, f entityFunc, args []string) error {
 	if len(args) < concurrency {
 		concurrency = len(args)
 	}
+
+	enc := encoding.For(c)
 	grp, ctx := errgroup.WithContext(c.Context)
 	for i := 0; i < concurrency; i++ {
 		grp.Go(func() error {
@@ -245,7 +250,7 @@ func entityWithArgs(c *cli.Context, f entityFunc, args []string) error {
 				if err != nil {
 					return err
 				}
-				if err := encoding.Encode(v); err != nil {
+				if err := enc.Encode(v); err != nil {
 					return err
 				}
 			}
@@ -338,7 +343,7 @@ var streamsetsCommand = &cli.Command{
 		if err != nil {
 			return err
 		}
-		if err := encoding.Encode(client.Activity.StreamSets()); err != nil {
+		if err := encoding.For(c).Encode(client.Activity.StreamSets()); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/commands/activity/strava/web.go
+++ b/pkg/commands/activity/strava/web.go
@@ -104,7 +104,7 @@ func fitness(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	return encoding.Encode(load)
+	return encoding.For(c).Encode(load)
 }
 
 var fitnessCommand = &cli.Command{

--- a/pkg/commands/activity/strava/webhook.go
+++ b/pkg/commands/activity/strava/webhook.go
@@ -34,7 +34,7 @@ func whlist(c *cli.Context) error {
 	active := false
 	err := list(c, func(sub *strava.WebhookSubscription) error {
 		active = true
-		return encoding.Encode(sub)
+		return encoding.For(c).Encode(sub)
 	})
 	if err != nil {
 		return err
@@ -78,7 +78,7 @@ func whsubscribe(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	return encoding.Encode(ack)
+	return encoding.For(c).Encode(ack)
 }
 
 var verifyFlag = &cli.StringFlag{

--- a/pkg/commands/activity/wta/wta.go
+++ b/pkg/commands/activity/wta/wta.go
@@ -24,6 +24,7 @@ var Command = &cli.Command{
 		if err != nil {
 			return err
 		}
+		enc := encoding.For(c)
 		for _, arg := range args {
 			ctx, cancel := context.WithTimeout(c.Context, c.Duration("timeout"))
 			defer cancel()
@@ -31,7 +32,7 @@ var Command = &cli.Command{
 			if err != nil {
 				return err
 			}
-			if err = encoding.Encode(reports); err != nil {
+			if err = enc.Encode(reports); err != nil {
 				return err
 			}
 		}

--- a/pkg/commands/activity/zwift/zwift.go
+++ b/pkg/commands/activity/zwift/zwift.go
@@ -47,6 +47,7 @@ func athlete(c *cli.Context) error {
 	if len(args) == 0 {
 		args = append(args, zwift.Me)
 	}
+	enc := encoding.For(c)
 	for i := range args {
 		ctx, cancel := context.WithTimeout(c.Context, c.Duration("timeout"))
 		defer cancel()
@@ -54,7 +55,7 @@ func athlete(c *cli.Context) error {
 		if err != nil {
 			return err
 		}
-		if err = encoding.Encode(profile); err != nil {
+		if err = enc.Encode(profile); err != nil {
 			return err
 		}
 	}
@@ -80,7 +81,7 @@ func refresh(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	return encoding.Encode(token)
+	return encoding.For(c).Encode(token)
 }
 
 var refreshCommand = &cli.Command{
@@ -106,7 +107,7 @@ func activities(c *cli.Context) error {
 		return err
 	}
 	for i := range acts {
-		if err = encoding.Encode(acts[i]); err != nil {
+		if err = encoding.For(c).Encode(acts[i]); err != nil {
 			return err
 		}
 	}
@@ -167,7 +168,7 @@ var activityCommand = &cli.Command{
 	ArgsUsage: "ACTIVITY_ID (...)",
 	Action: func(c *cli.Context) error {
 		return entity(c, func(_ context.Context, _ *zwift.Client, act *zwift.Activity) error {
-			return encoding.Encode(act)
+			return encoding.For(c).Encode(act)
 		})
 	},
 }
@@ -254,7 +255,7 @@ func files(c *cli.Context) error {
 			return err
 		}
 	}
-	return encoding.Encode(paths)
+	return encoding.For(c).Encode(paths)
 }
 
 var filesCommand = &cli.Command{

--- a/pkg/commands/analysis/analysis.go
+++ b/pkg/commands/analysis/analysis.go
@@ -103,7 +103,7 @@ func analyze(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	return encoding.Encode(results)
+	return encoding.For(c).Encode(results)
 }
 
 var listCommand = &cli.Command{
@@ -117,7 +117,7 @@ var listCommand = &cli.Command{
 			res[nm]["base"] = an.standard
 			res[nm]["flags"] = (an.analyzer.Flags != nil)
 		}
-		return encoding.Encode(res)
+		return encoding.For(c).Encode(res)
 	},
 }
 

--- a/pkg/commands/encoding/encoding.go
+++ b/pkg/commands/encoding/encoding.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/urfave/cli/v2"
 
 	"github.com/bzimmer/gravl/pkg/providers/activity"
 	"github.com/bzimmer/gravl/pkg/providers/geo"
@@ -20,31 +21,8 @@ type Encoder interface {
 	Encode(v interface{}) error
 }
 
-var DefaultEncoder = "json"
-var encoders = make(map[string]Encoder)
-
-var Encode = func(v interface{}) error {
-	enc, err := For(DefaultEncoder)
-	if err != nil {
-		return err
-	}
-	return enc.Encode(v)
-}
-
-// Add the encoder for the encoding if no prior encoder exists
-//
-// This function is not thread-safe
-func Add(encoder Encoder) {
-	encoders[encoder.Name()] = encoder
-}
-
-// For name return an encoder
-func For(encoder string) (Encoder, error) {
-	enc, ok := encoders[encoder]
-	if !ok {
-		return nil, ErrUnknownEncoder
-	}
-	return enc, nil
+func For(c *cli.Context) Encoder {
+	return c.App.Metadata["enc"].(Encoder)
 }
 
 type namedEncoder struct {

--- a/pkg/commands/geo/gnis/gnis.go
+++ b/pkg/commands/geo/gnis/gnis.go
@@ -14,6 +14,7 @@ func query(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	enc := encoding.For(c)
 	args := c.Args()
 	for i := 0; i < args.Len(); i++ {
 		ctx, cancel := context.WithTimeout(c.Context, c.Duration("timeout"))
@@ -23,7 +24,7 @@ func query(c *cli.Context) error {
 			return err
 		}
 		for _, x := range features {
-			if err = encoding.Encode(x); err != nil {
+			if err = enc.Encode(x); err != nil {
 				return err
 			}
 		}

--- a/pkg/commands/geo/gpx/gpx.go
+++ b/pkg/commands/geo/gpx/gpx.go
@@ -12,6 +12,7 @@ import (
 )
 
 func info(c *cli.Context) error {
+	enc := encoding.For(c)
 	for _, arg := range c.Args().Slice() {
 		fp, err := os.Open(arg)
 		if err != nil {
@@ -29,14 +30,14 @@ func info(c *cli.Context) error {
 		s := geo.SummarizeTracks(x)
 		if s.Tracks > 0 {
 			s.Filename = arg
-			if err := encoding.Encode(s); err != nil {
+			if err := enc.Encode(s); err != nil {
 				return err
 			}
 		}
 		s = geo.SummarizeRoutes(x)
 		if s.Routes > 0 {
 			s.Filename = arg
-			if err := encoding.Encode(s); err != nil {
+			if err := enc.Encode(s); err != nil {
 				return err
 			}
 		}

--- a/pkg/commands/geo/srtm/srtm.go
+++ b/pkg/commands/geo/srtm/srtm.go
@@ -48,6 +48,6 @@ var Command = &cli.Command{
 		if err != nil {
 			return err
 		}
-		return encoding.Encode(elevation)
+		return encoding.For(c).Encode(elevation)
 	},
 }

--- a/pkg/commands/manual/manual.go
+++ b/pkg/commands/manual/manual.go
@@ -250,6 +250,6 @@ var Commands = &cli.Command{
 		for _, c := range lineate(c.App.Commands, nil) {
 			s = append(s, cmd+" "+c.fullname(" "))
 		}
-		return encoding.Encode(s)
+		return encoding.For(c).Encode(s)
 	},
 }

--- a/pkg/commands/store/store.go
+++ b/pkg/commands/store/store.go
@@ -115,7 +115,7 @@ func export(c *cli.Context) error {
 			if err != nil {
 				return err
 			}
-			if err := encoding.Encode(y); err != nil {
+			if err := encoding.For(c).Encode(y); err != nil {
 				return err
 			}
 			i++
@@ -168,7 +168,7 @@ collect:
 			return err
 		}
 	}
-	if err := encoding.Encode(ids); err != nil {
+	if err := encoding.For(c).Encode(ids); err != nil {
 		return err
 	}
 	return nil
@@ -230,7 +230,7 @@ update:
 	if err = grp.Wait(); err != nil {
 		return err
 	}
-	return encoding.Encode(map[string]int{"total": total, "new": n, "existing": total - n})
+	return encoding.For(c).Encode(map[string]int{"total": total, "new": n, "existing": total - n})
 }
 
 var updateCommand = &cli.Command{

--- a/pkg/commands/version/version.go
+++ b/pkg/commands/version/version.go
@@ -11,7 +11,7 @@ var Command = &cli.Command{
 	Name:  "version",
 	Usage: "Version",
 	Action: func(c *cli.Context) error {
-		return encoding.Encode(map[string]string{
+		return encoding.For(c).Encode(map[string]string{
 			"version":    pkg.BuildVersion,
 			"timestamp":  pkg.BuildTime,
 			"user-agent": pkg.UserAgent,

--- a/pkg/commands/wx/noaa/noaa.go
+++ b/pkg/commands/wx/noaa/noaa.go
@@ -29,7 +29,7 @@ func forecast(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	return encoding.Encode(fcst)
+	return encoding.For(c).Encode(fcst)
 }
 
 var Command = &cli.Command{

--- a/pkg/commands/wx/openweather/openweather.go
+++ b/pkg/commands/wx/openweather/openweather.go
@@ -33,7 +33,7 @@ func forecast(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	return encoding.Encode(fcst)
+	return encoding.For(c).Encode(fcst)
 }
 
 var Command = &cli.Command{

--- a/pkg/commands/wx/visualcrossing/visualcrossing.go
+++ b/pkg/commands/wx/visualcrossing/visualcrossing.go
@@ -33,7 +33,7 @@ func forecast(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	return encoding.Encode(fcst)
+	return encoding.For(c).Encode(fcst)
 }
 
 var Command = &cli.Command{


### PR DESCRIPTION
The prior implementation for accessing the encoder in the cli was known to be problematic. This simplifies access and removes all contention when accessed by more than one goroutine.
